### PR TITLE
Create text embedding dataset, with Wikipedia examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ high-dimensional vectors stemming from recent deep learning models. The availabl
 * [open-images](openimages/README.md) [[2]](#2)
 * [rqa](rqa/README.md) [[3]](#3)
 * [wit](wit/README.md) [[3]](#3)
+* [wikipedia](text/README.md)
 
 Please see the details of each dataset in the respective README files.
 

--- a/text/README.md
+++ b/text/README.md
@@ -1,0 +1,131 @@
+# Text Dataset Generator
+
+This provides code to generate vector embedding datasets from text and save them to 
+`fvecs` format for use in similarity search applications (e.g. retrieval-augmented 
+generation with LLMs). The code assumes that the text embedding model is available 
+through the popular [SentenceTransformers](https://sbert.net/) library.
+
+Since many text datasets and embedding models are increasing in size, the code enables data 
+parallelism in two different ways: by sharding the dataset samples (allowing multiple 
+nodes to process different shards and combine later) and by running inference on 
+multiple devices at once (allowing many GPUs within a node to be used on different 
+parts of the data).
+
+More specifically, we provide two examples to generate datasets using text 
+from the [KILT](https://ai.meta.com/tools/kilt/) (Knowledge Intensive Language Tasks) 
+benchmark Wikipedia dump [[1]](#1). Our examples use multi-GPU parallelism within a node, and 
+process shards sequentially within that node. Here the sharding enables the user to 
+process shards on a node with limited storage, and moves each shard to a final location 
+with more storage.
+
+### 3rd Party Dataset Disclaimer
+Please see the dataset's applicable license for terms and conditions. Intel 
+does not own the rights to this data set and does not confer any rights to 
+it. Intel does not warrant or assume responsibility for the accuracy or 
+completeness of any information, text, graphics, links or other items within 
+the dataset.
+
+## wiki-45M dataset
+
+This version of the dataset relies on the original KILT repository archived 
+[here](https://github.com/facebookresearch/KILT). To reproduce the dataset, one should clone
+ this repository and follow the pip installation instructions. The script we have provided,
+`preprocess_kilt_data.py`, is a modified version of `KILT/scripts/create_kilt_data_paragraphs.py`. 
+The main differences are:
+* Our version creates text chunks based on the number of words, rather than the number of 
+`nltk` tokens. This means that punctuations are not counted separately in the chunk length, 
+resulting in an overall reduction of the number of chunks (45M compared to 110M below).
+* We found that the original preprocessing could produce confusing results if the vectors are 
+used for text retrieval. To help alleviate this, we added a step to prepend the section title 
+to a chunk if it begins with a bullet point.
+* We modified the multiprocessing to rely on `tqdm.contrib.concurrent.process_map`, which 
+automatically handles some functions like launching the multiprocessing pool.
+
+To actually download the Wikipedia dataset and launch the preprocessing, follow the steps as 
+outlined in the original repository. We summarize the commands below:
+1. Download the 35GB KILT knowledge source as provided in the archived repository. Use mongoDB 
+to index the knowledge base as follows:
+```
+wget http://dl.fbaipublicfiles.com/KILT/kilt_knowledgesource.json
+mongoimport --db kilt --collection knowledgesource --file kilt_knowledgesource.json
+```
+2. Launch preprocessing, which splits the DB into however many `threads` you specify and saves them.
+```
+python preprocess_kilt_data.py --step preprocess --folder "./kilt_data" --threads 64
+```
+3. Divide the text data into 100 word chunks. To process one part of the database, provide that index 
+as `rank`. This allows you to parallelize this step.
+```
+python preprocess_kilt_data.py --step main --chunk_size 100 --folder "./kilt_data" --rank <int>
+```
+4. Merge all of the parts of the preprocessed data together.
+```
+python preprocess_kilt_data.py --step merge --folder "./kilt_data" --threads 64
+```
+This will give us one `.jsonl` file that contains all of the text chunks for the entire dataset.
+
+Now we can execute the `wikipedia_dataset.py` script with our desired parameters. We will pass the
+preprocessed file to the `json_name` argument of the script. The example command below will use the
+large, 1536-dimensional text embedding model created by Alibaba,
+[gte-Qwen2-1.5B-instruct](https://huggingface.co/Alibaba-NLP/gte-Qwen2-1.5B-instruct).
+
+```
+python wikipedia_dataset.py \
+    --data_dir "./wiki_data_dir" --output_dir "./wiki_data_dir" \
+    --embed_model "Alibaba-NLP/gte-Qwen2-1-5B-instruct" --embed_size 1536 \
+    --dataset_name wiki
+    --json_name "./kilt_data/kilt.jsonl" 
+    --number_vec_shards 12 \
+    --multiproc \
+    --batch_size 64 --chunk_size 960 \
+    --output_prefix wiki-45M --final_output_dir "./vector_data" 
+```
+The batch size and chunk size should be customized to your hardware. This will be limited by the GPU
+memory you have available. All embeddings are written to memory-mapped numpy arrays.
+
+If your job stops for any reason, you may resume the embedding by passing the index of the vector
+where you want to continue processing the data with `--start_vector_index {vector_index}`. This index
+should correspond to the number of total samples in the dataset, i.e. for wiki-45M that maximum is
+45366081. The total number of samples will be printed out when you run the script.
+
+The result of the script will be an `fvecs` file containing all of the embeddings. This will be created
+from a numpy file that has merged all of the dataset shards together.
+
+
+## wikipedia_110M dataset
+
+You simply need to execute the `wikipedia_dataset.py` script with the desired 
+arguments. We will be using an already preprocessed version of the KILT Wikipedia dataset available 
+from the authors of the [RAGGED paper](https://github.com/neulab/ragged)[[2]](#2). 
+
+In our example below, we'll be using a 1024-dimensional text embedding model created by BAAI, 
+[bge-large-en-v1.5](https://huggingface.co/BAAI/bge-large-en-v1.5).
+By dividing the dataset into 8 shards, we will create individual shards that are about ~50GB each.
+
+Unlike the previous example, we provide an argument `--data_key`. This is because we use the HuggingFace 
+`datasets` library to load the data, and it encodes the text data in one of the dataset fields. For
+the preprocessed version we downloaded from the HuggingFace Hub, this field is `contents`.
+
+```
+python wikipedia_dataset.py \
+    --data_dir "./wiki_data_dir" --output_dir "./wiki_data_dir" \
+    --hf_path "jenhsia/ragged" --data_key "contents" \
+    --dataset_name "kilt_wikipedia" \
+    --embed_model "BAAI/bge-large-en-v1.5 --embed_size 1024 \
+    --multiproc \
+    --number_vec_shards 8 \
+    --batch_size 512 --chunk_size 5000 \
+    --output_prefix kilt_wikipedia_110M --final_output_dir "./vector_data" 
+```
+
+## References
+
+<a id="1">[1]</a> 
+Petroni, F.; Piktus, A.; Fan, A.; Lewis, P.; Yazdani, M.; De Cao, N.; Thorne, J.; Jernite, Y.; Karpukhin, V.; 
+Maillard, J.; Plachouras, V.; Rockt{\"a}schel, T.; Riedel, S.: KILT: a Benchmark for Knowledge Intensive Language Tasks. 
+In: Proceedings of the 2021 Conference of the North American Chapter of the Association for Computational Linguistics: 
+Human Language Technologies (NAACL). 2523-2544. (2021)
+
+<a id="2">[2]</a>
+Hsia, J.; Shaikh, A.; Wang, Z.; Neubig, G.: RAGGED: Towards Informed Design of Retrieval Augmented Generation Systems.
+arXiv:2403.09040. (2024) 

--- a/text/preprocess_kilt_data.py
+++ b/text/preprocess_kilt_data.py
@@ -1,0 +1,300 @@
+# Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: MIT
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Original Facebook LICENSE file:
+# https://github.com/facebookresearch/KILT/blob/2664322b9a994be686e4c3a9e8f75a0b70927f22/LICENSE
+
+import multiprocessing
+from multiprocessing.pool import ThreadPool
+import sys
+import argparse
+import pickle
+import json
+import os
+import spacy
+from tqdm import tqdm, trange
+from tqdm.contrib.concurrent import process_map
+
+import kilt.kilt_utils as utils
+from kilt.knowledge_source import KnowledgeSource
+
+
+def create_chunk(document, buffer, paragraph_id, paragraph, section, prepend_section):
+    start = buffer[0].idx
+    end = buffer[-1].idx + len(buffer[-1])
+
+    anchors = [
+        {
+            "text": anchor["text"],
+            "href": anchor["href"],
+            "source": {
+                "paragraph_id": anchor["paragraph_id"],
+                "start": anchor["start"],
+                "end": anchor["end"],
+            },
+            "start": anchor["start"] - start,
+            "end": anchor["end"] - start,
+        }
+        for anchor in document["anchors"]
+        if anchor["paragraph_id"] == paragraph_id
+        and anchor["start"] >= start
+        and anchor["end"] <= end
+    ]
+    par_text = paragraph.text[start : end + 1].strip()
+    if prepend_section:
+        par_text = f"{section} {par_text}"
+    n_words = len(par_text.split())
+
+    return {
+        "_id": document["_id"],
+        "wikipedia_id": document["wikipedia_id"],
+        "wikipedia_title": document["wikipedia_title"],
+        "text": par_text,  #paragraph.text[start : end + 1].strip(),
+        "tmp_len": n_words,  #len(buffer),
+        "anchors": anchors,
+        "categories": document["categories"],
+        "history": document["history"],
+        "sources": [{"paragraph_id": paragraph_id, "start": start, "end": end,}],
+        "section": section,
+    }
+
+
+def run_thread(args):
+    documents = args["documents"]
+    nlp = args["nlp"]
+    id = args["id"]
+    rank = args["rank"]
+    chunk_size = args["chunk_size"]
+
+    #iter_ = tqdm(documents)
+    #if id == 0 and rank == 0:
+    #    iter_ = tqdm(documents)
+    #else:
+    iter_ = documents
+
+    # initialization
+    output = []
+
+    for document in iter_:
+
+        # initialization
+        prepend_section = False
+        buffer_words, buffer_toks = [], []
+        nwords_buffer = 0
+        section = "Section::::Abstract"
+
+        # loop paragrpahs removing first (title)
+        for paragraph_id, paragraph in enumerate(nlp.pipe(document["text"][1:]), 1):
+
+            # if section then save name and move on
+            if "Section::::" in paragraph.text:
+                section = paragraph.text.strip()
+                continue
+            # if the paragraph begins with a bullet point, prepend the section title to the text as well.
+            if paragraph.text[:10] == "BULLET::::":
+                buffer_words += section.split()
+                prepend_section = True
+
+            for sentence in paragraph.sents:
+                sent_words = sentence.text.split()
+                if buffer_toks and len(buffer_words) + len(sent_words) >= chunk_size:
+                    # create new chunk
+                    new_chunk = create_chunk(
+                        document, buffer_toks,
+                        paragraph_id, paragraph, section, prepend_section
+                    )
+                    output.append(new_chunk)
+                    buffer_words, buffer_toks = [], []
+                    prepend_section = False
+
+                # Use number of words, not number of tokens
+                buffer_words += sent_words
+                for token in sentence:
+                    word = token.text.strip()
+                    if word and len(word) > 0:
+                        buffer_toks.append(token)
+
+            if buffer_words:
+                # create new chunk
+                new_chunk = create_chunk(
+                    document, buffer_toks,
+                    paragraph_id, paragraph, section, prepend_section
+                )
+
+                # conditions on merging with previous chunk
+                if (
+                    output
+                    and document["wikipedia_id"] == output[-1]["wikipedia_id"]
+                    and section == output[-1]["section"]
+                    and len(buffer_words) + output[-1]["tmp_len"] < chunk_size
+                ):
+
+                    # adjusting anchors offsets
+                    for anchor in new_chunk["anchors"]:
+                        anchor["start"] += len(output[-1]["text"]) + 1
+                        anchor["end"] += len(output[-1]["text"]) + 1
+
+                    # remove redundant section title preprended to current chunk
+                    if prepend_section:
+                        new_chunk["text"] = new_chunk["text"][len(section):]
+                    # appending new data
+                    output[-1]["text"] += " " + new_chunk["text"]
+                    output[-1]["anchors"] += new_chunk["anchors"]
+                    output[-1]["sources"] += new_chunk["sources"]
+                    output[-1]["tmp_len"] += new_chunk["tmp_len"] #+ 1
+                else:
+                    output.append(new_chunk)
+                buffer_words, buffer_toks = [], []
+                prepend_section = False
+
+    for out in output:
+        del out["tmp_len"]
+
+    return output
+
+
+def store_chunks(documents, num_threads, folder):
+    for id, chunk in enumerate(utils.chunk_it(documents, num_threads)):
+        out_filename = os.path.join(folder, "documents_{}.p".format(id))
+        pickle.dump(chunk, open(out_filename, "wb"))
+
+
+def load_chunk(id, folder):
+    in_filename = os.path.join(folder, "documents_{}.p".format(id))
+    return pickle.load(open(in_filename, "rb"))
+
+
+def load_all_documents_from_ks(cursor, steps, n):
+    documents = []
+    j = 0
+    for document in cursor:
+        if j % steps == 0:
+            sys.stdout.write("{}/{} \r".format(j, n))
+            sys.stdout.flush()
+        documents.append(document)
+        j += 1
+    return documents
+
+
+def preprocess_data(num_threads, folder):
+
+    ks = KnowledgeSource()
+    n = ks.get_num_pages()
+    steps = int(n / 100)
+
+    cursor = ks.get_all_pages_cursor()
+
+    print("LOADING ALL DOCUMENTS", flush=True)
+    ducuments = load_all_documents_from_ks(cursor, steps, n)
+    store_chunks(ducuments, num_threads, folder)
+
+
+def main(rank, num_threads, folder, chunk_size):
+
+    print("loading chunk {}".format(rank), flush=True)
+    documents = load_chunk(rank, folder)
+
+    arguments = [
+        {
+            "rank": rank,
+            "id": id,
+            "documents": chunk,
+            "nlp": spacy.load("en_core_web_sm"),
+            "chunk_size": chunk_size,
+        }
+        for id, chunk in enumerate(utils.chunk_it(documents, num_threads))
+    ]
+
+    #print("starting {} threads in {}".format(num_threads, rank))
+    #pool = ThreadPool(num_threads)
+    #results = pool.map(run_thread, arguments)
+    results = process_map(run_thread, arguments, max_workers=num_threads)
+
+    f = open(os.path.join(folder, "kilt_{}.jsonl".format(rank)), "w+",)
+
+    i = 1
+    for output in results:
+        for msg in output:
+            f.write("{}\t{}\n".format(i, json.dumps(msg)))
+            i += 1
+    f.close()
+    #pool.terminate()
+    #pool.join()
+    print("done {}".format(rank))
+
+
+def merge_files(num_threads, folder):
+
+    f = open(os.path.join(folder, "kilt.jsonl"), "w+")
+    i = 1
+    for rank in trange(num_threads):
+        filename = os.path.join(folder, "kilt_{}.jsonl".format(rank))
+        print("reading {}".format(filename), flush=True)
+        with open(filename, "r") as fin:
+            lines = fin.readlines()
+            for line in tqdm(lines):
+                elements = line.split("\t")
+                if len(elements) != 2:
+                    print(
+                        "ERROR: len(elements)!=2 -> {}".format(len(elements)),
+                        flush=True,
+                    )
+                else:
+                    #f.write("{}\t{}\n".format(i, elements[1].strip()))
+                    f.write("{}\n".format(elements[1].strip()))
+                    i += 1
+    f.close()
+    print("done")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--step",
+        type=str,
+        choices=["preprocess", "main", "merge"],
+        help="step to exectue",
+    )
+
+    parser.add_argument(
+        "--chunk_size", default=100, type=int, help="chunk max token size",
+    )
+
+    parser.add_argument(
+        "--folder", type=str, help="path where to save and load files",
+    )
+
+    parser.add_argument(
+        "--rank", default=None, type=int, help="rank in a distributed execution",
+    )
+
+    parser.add_argument(
+        "--threads", default=None, type=int, help="number of threads",
+    )
+
+    args = parser.parse_args()
+
+    if args.threads == None:
+        args.threads = int(multiprocessing.cpu_count())
+
+    # step 1
+    if args.step == "preprocess":
+        preprocess_data(num_threads=args.threads, folder=args.folder)
+    # step 2
+    elif args.step == "main":
+        main(
+            rank=args.rank,
+            num_threads=args.threads,
+            folder=args.folder,
+            chunk_size=args.chunk_size,
+        )
+    # step 3
+    elif args.step == "merge":
+        merge_files(num_threads=args.threads, folder=args.folder)

--- a/text/requirements_text.txt
+++ b/text/requirements_text.txt
@@ -1,0 +1,6 @@
+datasets>=2.8.0
+numpy
+sentence_transformers>=3.0.0
+spacy
+torch
+tqdm>=4.62.2

--- a/text/text_dataset_generate.py
+++ b/text/text_dataset_generate.py
@@ -1,0 +1,329 @@
+"""
+Can be used to generate vector embeddings of a HuggingFace-compatible dataset using SentenceTransformers. Assumes the
+use of a text dataset. Has features to parallelize encoding across data samples.
+
+1) Loads the dataset from a JSONL file with the HuggingFace datasets library.
+    - The data in the JSONL file should have a field that corresponds to the already chunked text, where each line in
+    the JSONL corresponds to a single chunk / single data sample. The name of this data field should be specified here
+    with the input argument --data_key.
+    - Saves the HuggingFace dataset to disk using pyarrow shards. If this dataset has already been created from a JSONL
+    previously, it will simply load it from these shards instead of re-constructing it from the JSONL.
+2) Using a model from SentenceTransformers, creates embeddings for each sample.
+    - Writes to a memory-mapped numpy file.
+    - Can start and stop embeddings with --start_vector and --end_vector indices. This allows you to resume a previously
+      terminated job.
+    - To handle very large datasets, the dataset processing can be broken into multiple shards. You specify the number
+      of shards, and the script will nearly evenly split the dataset into that number of shards. You can specify the
+      index of the vector to start and end with for a call to this script. The script will automatically determine
+      which shard to write into and resume dataset creation from there. This can enable inter-node data parallelism
+      (e.g. one shard per node).
+    - To handle very large datasets, you can enable intra-node data parallelism with --multiproc. This allows you to
+      recruit each GPU to encode a different portion of the dataset.
+"""
+import datasets as ds
+import gc
+import glob
+import math
+import numpy as np
+import numpy.typing as npt
+import os
+import sentence_transformers as st
+import tqdm
+import torch.utils.data
+from typing import List, Dict, Optional
+
+
+class MMAPSentenceTransformer(st.SentenceTransformer):
+    """
+    Subclass to write directly to a memory mapped file with multiprocessing. Overwrites encode_multi_process()
+    function to do this. Still relies on the original class' implementation of _encode_multi_process_worker,
+    as well as the functions to start and stop the multiprocessing pool.
+    
+    This modification was written for sentence-transformers==3.0.0 from conda-forge. An older version did not use the
+    `precision` argument in the queue, and future versions may require other changes.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def encode_multi_process(
+        self,
+        mmap_fname: str,
+        sentences: List[str],
+        pool: Dict[str, object],
+        emb_size: int = None,
+        batch_size: int = 32,
+        chunk_size: int = None,
+        start_chunk: int = 0,
+        end_chunk: int = None,
+        normalize_embeddings: bool = False,
+        prompt_name: Optional[str] = None,
+        prompt: Optional[str] = None,
+    ):
+        """
+        This method allows to run encode() on multiple GPUs. The sentences are chunked into smaller packages
+        and sent to individual processes, which encode these on the different GPUs. This method is only suitable
+        for encoding large sets of sentences
+
+        :param prompt_name: The name of the prompt to use for encoding. Must be a key in the `prompts` dictionary,
+            which is either set in the constructor or loaded from the model configuration. For example if
+            `prompt_name` is ``"query"`` and the `prompts` is ``{"query": "query: {}", ...}``, then the sentence "What
+            is the capital of France?" will be encoded as "query: What is the capital of France?". If `prompt` is
+            also set, this argument is ignored.
+        :param prompt: The prompt to use for encoding. For example, if the prompt is ``"query: {}"``, then the
+            sentence "What is the capital of France?" will be encoded as "query: What is the capital of France?".
+            If `prompt` is set, `prompt_name` is ignored.
+        :return: 2d numpy array with shape [num_inputs, output_dimension]
+        """
+        precision = "float32"
+        if os.path.exists(mmap_fname):
+            print(f"Opening existing memory mapped file to write into: {mmap_fname} {len(sentences), emb_size}")
+            mmap = np.memmap(mmap_fname, dtype='float32', mode="r+",
+                             shape=(len(sentences), emb_size))
+        else:
+            print(f"Creating new memory mapped file to write into: {mmap_fname} {len(sentences), emb_size}")
+            mmap = np.memmap(mmap_fname, dtype='float32', mode="w+",
+                             shape=(len(sentences), emb_size))
+
+        if chunk_size is None:
+            chunk_size = min(math.ceil(len(sentences) / len(pool["processes"]) / 10), 5000)
+        if end_chunk is None:
+            end_chunk = (len(sentences)//chunk_size) + 1
+
+        print(f"Chunk data into {math.ceil(len(sentences) / chunk_size)} packages of size {chunk_size}")
+
+        input_queue = pool["input"]
+        last_chunk_id = 0
+        chunk = []
+
+        for sentence in sentences:
+            chunk.append(sentence)
+            if len(chunk) >= chunk_size:
+                if last_chunk_id < start_chunk:
+                    chunk = []
+                    last_chunk_id += 1
+                    continue
+                elif last_chunk_id == start_chunk:
+                    print(f"Sending sentences starting from chunk {last_chunk_id}, vector index {last_chunk_id*chunk_size}")
+                if last_chunk_id >= end_chunk:
+                    print(f"Stopping sentences at chunk {last_chunk_id}")
+                    chunk = []
+                    break
+                input_queue.put([last_chunk_id, batch_size, chunk, prompt_name, prompt, precision, normalize_embeddings])
+                last_chunk_id += 1
+                chunk = []
+
+        if len(chunk) > 0:
+            input_queue.put([last_chunk_id, batch_size, chunk, prompt_name, prompt, precision, normalize_embeddings])
+            last_chunk_id += 1
+
+        output_queue = pool["output"]
+        for _ in tqdm.tqdm(range(start_chunk, last_chunk_id)):
+            chunki, embs = output_queue.get()
+            starti = chunki*chunk_size
+            endi = starti + chunk_size
+            mmap[starti:endi, :] = embs
+            mmap.flush()
+        mmap._mmap.close()
+        del mmap
+        gc.collect()
+
+
+def load_dataset_hf_or_jsonl(dataset_name, data_dir, json_name=None, hf_path=None):
+    """
+    Loads a text dataset, either from a JSONL file or a HuggingFace data repository.
+    Assumes the data has already been preprocessed. Each data sample should correspond to a single chunk of text.
+    This function implements its own disk caching. This implementation (1) allows easy movement of the data to a new
+    machine and (2) ensures that caching is only performed once, and is not repeated if the HuggingFace fingerprint
+    changes because of changes to the surrounding code.
+
+    :param dataset_name: Name of the dataset to use in dataset disk caching. If loading from HuggingFace Hub,
+                         this should also be the `name` argument to `datasets.load_dataset()`.
+    :param data_dir: Directory for the dataset arrow files, e.g. the HuggingFace dataset cache folder.
+    :param json_name: default None. Full path to the JSONL file. If None, `hf_path` must be specified.
+    :param hf_path: default None. Path to the HuggingFace dataset repository. If None, `json_name` must be specified.
+    :return: data, an instance of a datasets.Dataset class.
+    """
+    # Load dataset.
+    shard_proc_path = f"{data_dir}/processed_{dataset_name}"
+    if os.path.exists(shard_proc_path):
+        print(f"Found previously loaded data, loading from {shard_proc_path}")
+        data = ds.load_from_disk(shard_proc_path)
+    else:
+        print(f"Did not find dataset in {shard_proc_path}...")
+        # Preprocess: make each paragraph a separate sample, keep metadata
+        print(f"Loading dataset {dataset_name}...")
+        if json_name:
+            data = ds.load_dataset("json", data_files=f"{json_name}")
+        elif hf_path:
+            data = ds.load_dataset(hf_path, dataset_name, cache_dir=data_dir)
+            print("WARNING: we are assuming you want the `train` split.")
+        else:
+            raise ValueError("Either json_name or hf_path must be specified!")
+        data = data['train']
+        # Save the pre-processed version in shards
+        data.save_to_disk(shard_proc_path, max_shard_size="500MB")
+        print("Saved preprocessed data!")
+    return data
+
+
+def generate_text_embeddings(data, embed_model, number_vec_shards, embed_size, batch_size, chunk_size,
+                             tmp_output_dir, output_prefix, start_vector=0, end_vector=None,
+                             data_key='text', multiproc=True):
+    # Load embedding model
+    print(f"Loading embedding model {embed_model}")
+    embed_model = MMAPSentenceTransformer(embed_model, trust_remote_code=True)
+
+    # Write to memory mapped numpy file
+    os.makedirs(tmp_output_dir, exist_ok=True)
+    nsentences = len(data)
+    print(f"Found a total of {nsentences} samples in the dataset.")
+    if number_vec_shards == 1:
+        output_fn = f"{tmp_output_dir}/{output_prefix}_tmp.mmap"
+        sentence_data = data[data_key]
+        ns = nsentences
+        start_vector = start_vector if start_vector else 0
+        end_vector = ns if end_vector is None else end_vector
+    elif number_vec_shards > 1:
+        # Shard the data and write several output files to combine at end
+        # Get sample indices for the relevant shard
+        shard_edges = np.arange(0, nsentences, nsentences // number_vec_shards)
+        shard_edges[-1] = nsentences  # encompass the last item in the bin
+        # Determine which shard we're processing
+        shard_id = np.digitize(start_vector, shard_edges) - 1
+        left_edge, right_edge = shard_edges[shard_id:shard_id+2]
+        sentence_data = data[data_key][left_edge:right_edge]
+        # Set start & end vectors relative to the shard
+        start_vector = start_vector - left_edge
+        ns = right_edge - left_edge   # shard size
+        end_vector = ns
+        output_fn = f"{tmp_output_dir}/{output_prefix}-{shard_id}_tmp.mmap"
+    else:
+        raise ValueError("number_vec_shards should be >= 1")
+    del data
+
+    if multiproc:
+        assert torch.cuda.is_available(), "GPUs for multiprocessing not detected."
+        print(f"Starting multiprocessing pool...")
+        pool = embed_model.start_multi_process_pool()
+        print(f"Embedding {ns} vectors...")
+        try:
+            start_chunk = start_vector // chunk_size
+            end_chunk = (end_vector // chunk_size) + 1
+            embed_model.encode_multi_process(mmap_fname=output_fn, pool=pool,
+                                             emb_size=embed_size,
+                                             sentences=sentence_data,
+                                             batch_size=batch_size,
+                                             chunk_size=chunk_size,
+                                             start_chunk=start_chunk,
+                                             end_chunk=end_chunk)
+        except Exception as e:
+            print("Error, closing pool")
+            embed_model.stop_multi_process_pool(pool)
+            raise e
+        embed_model.stop_multi_process_pool(pool)
+        del embed_model
+        gc.collect()
+        print(f"Finished multiprocessing.")
+    else:
+        if os.path.exists(output_fn):
+            print(f"Opening existing memory mapped file to write into: {output_fn}")
+            fout = np.memmap(output_fn, dtype=np.float32, mode="r+", shape=(ns, embed_size))
+        else:
+            fout = np.memmap(output_fn, dtype=np.float32, mode="w+", shape=(ns, embed_size))
+        start_chunk = start_vector // batch_size
+        end_chunk = (end_vector // batch_size) + 1
+        dl = torch.utils.data.DataLoader(sentence_data, batch_size=batch_size, shuffle=False)
+        print(f"Embedding {ns} vectors...")
+        for bi, batch in enumerate(tqdm.tqdm(dl)):
+            if bi < start_chunk:
+                continue
+            elif bi == start_chunk:
+                print(f"Writing embeddings starting from batch {bi}")
+            if bi >= end_chunk:
+                print(f"Stopping embedding writing at batch {bi}")
+                fout.flush()  # Not sure if necessary to flush
+                break
+            i = bi*batch_size
+            j = min(i + batch_size, end_vector)
+            fout[i:j, :] = embed_model.encode(batch, batch_size=batch_size)
+        fout._mmap.close()
+        del fout
+        gc.collect()
+
+
+def fvecs_write_from_mmap(fname: str, m: npt.ArrayLike):
+    n, d = m.shape
+    m1 = np.memmap(fname, dtype='int32', mode='w+', shape=(n, d + 1))
+    m1[:, 0] = d
+    m1[:, 1:] = m.view('int32')
+
+
+def convert_mmap_fvecs(input_fn, mmap_shape, output_fn):
+    """
+    Given an input file path directing to a memory mapped numpy file, load it and save in
+    SVS-compatible fvecs format. The memory mapped file needs to have a shape input so
+    it can be loaded by numpy.
+    """
+    if output_fn[-6:] != '.fvecs':
+        # Output file name should end in .fvecs
+        if os.path.isdir(output_fn):
+            base_file = os.path.basename(input_fn).split('.')[0]
+            output_fn = f"{output_fn}/{base_file}.fvecs"
+        else:
+            path = os.path.dirname(output_fn)
+            base = os.path.basename(output_fn).split('.')[0]
+            output_fn = f"{path}/{base}.fvecs"
+    print(f"Reading data from {input_fn} to write to {output_fn}")
+    fdata = np.memmap(input_fn, dtype='float32', mode="r", shape=mmap_shape)
+    print(f"Converting to fvecs...")
+    fvecs_write_from_mmap(output_fn, fdata)
+    print(f"Finished with {output_fn}!")
+
+
+def combine_mmaps(data_file_prefix, final_mmap_shape):
+    output_file_path = data_file_prefix + '_combined.mmap'
+    files_to_combine = glob.glob(f'{data_file_prefix}*[0-9]*_tmp.mmap')
+    n_files = len(files_to_combine)
+    files_to_combine = sorted(files_to_combine, key=lambda i: int(os.path.basename(i).split('-')[-1].split('_')[0])) if n_files > 1 else files_to_combine
+    if os.path.exists(output_file_path):
+        outf = np.memmap(output_file_path, dtype='float32', mode="r+", shape=final_mmap_shape)
+        rand_inds = np.concatenate((np.array([0, -1, -2, -10]),
+                                    np.random.randint(0, final_mmap_shape[0] - 2, 10)))
+        if np.any(np.sum(outf[rand_inds, :], axis=1) == 0):
+            print(f"Found combined mmap file, but some part of it is empty so overwriting!")
+            print(f"Combining memmap data across {n_files} files:\n{files_to_combine}")
+            outf = np.memmap(output_file_path, dtype='float32', mode="w+", shape=final_mmap_shape)
+        else:
+            print(f"Found combined mmap file! Reusing...")
+            return output_file_path
+    elif n_files > 1:
+        print(f"Combining memmap data across {n_files} files:\n{files_to_combine}")
+        outf = np.memmap(output_file_path, dtype='float32', mode="w+", shape=final_mmap_shape)
+    elif n_files == 0:
+        unsharded_file = glob.glob(f'{data_file_prefix}*.mmap')
+        if len(unsharded_file) == 1:
+            return unsharded_file[0]
+        else:
+            raise ValueError(f"Could not find any files following {data_file_prefix}*.mmap!")
+    elif n_files == 1:
+        print(f"Found one mmap file, assuming no combination is necessary...")
+        return files_to_combine[0]
+    nsamples = final_mmap_shape[0]
+    shard_edges = np.arange(0, nsamples, nsamples // n_files)
+    shard_edges[-1] = nsamples
+    file_dim0 = np.diff(shard_edges)
+    print(f"Shards at {shard_edges}, files contain {file_dim0} samples")
+    starti = 0
+    for d, fn in zip(file_dim0, files_to_combine):
+        try:
+            indata = np.memmap(fn, dtype='float32', mode="r", shape=(d, final_mmap_shape[1]))
+            print(f"Copying over data from {fn}")
+        except Exception as e:
+            print(e)
+            import pdb; pdb.set_trace()
+        outf[starti:starti+d, :] = indata
+        del indata
+        starti += d
+    del outf
+    print(f"Done combining!")
+    return output_file_path

--- a/text/wikipedia_dataset.py
+++ b/text/wikipedia_dataset.py
@@ -1,0 +1,90 @@
+import argparse
+import numpy as np
+import text_dataset_generate as tdg
+
+
+def main(embed_model, number_vec_shards, embed_size, batch_size, tmp_output_dir, output_prefix, final_output_dir,
+         data_dir, dataset_name, chunk_size=None, json_name=None, hf_path=None,
+         start_vector=0, end_vector=None, data_key='contents', multiproc=True, combine_only=False):
+    data = tdg.load_dataset_hf_or_jsonl(dataset_name, data_dir, json_name, hf_path)
+    n_samples = len(data)
+    if combine_only:
+        print("Skipping embedding, assuming files exist already...")
+    else:
+        if number_vec_shards > 1:
+            assert end_vector is None, "End vector should be none if you're sharding the data"
+            shard_edges = np.arange(0, n_samples, n_samples // number_vec_shards)
+            shard_start_indices = shard_edges[:-1]
+            shard_end_indices = shard_edges[1:]
+            do_shard = shard_end_indices > start_vector
+            shard_start_indices = shard_start_indices[do_shard]
+            for start_index in shard_start_indices:
+                start_vec = start_index if start_index >= start_vector else start_vector
+                tdg.generate_text_embeddings(data, embed_model, number_vec_shards, embed_size, batch_size, chunk_size,
+                                             tmp_output_dir, output_prefix, start_vec, end_vector, data_key, multiproc)
+        else:
+            tdg.generate_text_embeddings(data, embed_model, number_vec_shards, embed_size, batch_size, chunk_size,
+                                         tmp_output_dir, output_prefix, start_vector, end_vector, data_key, multiproc)
+    del data
+
+    # Combine & convert the numpy files to fvecs format
+    mmap_shape = (n_samples, embed_size)
+    output_file_prefix = f"{tmp_output_dir}/{output_prefix}"
+    mmap_path = tdg.combine_mmaps(output_file_prefix, mmap_shape)  # if there's only 1 shard this will do nothing
+    tdg.convert_mmap_fvecs(mmap_path, mmap_shape, final_output_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # embedding model arguments
+    parser.add_argument("-m", "--embed_model", type=str, required=True,
+                        help="Model ID for SentenceTransformers or HuggingFace")
+    parser.add_argument("-e", "--embed_size", type=int, required=True,
+                        help="Size of the embedding dimension")
+    # dataset arguments
+    parser.add_argument("-dn", "--dataset_name", type=str,
+                        help="Dataset name, e.g. `kilt_wikipedia`, for saving out the pyarrow dataset files. If you would like "
+                             "the dataset to be downloaded from HuggingFace, this should be the `name` argument to "
+                             "datasets.load_dataset().")
+    parser.add_argument("-dd", "--data_dir", type=str, required=True,
+                        help="HuggingFace dataset cache folder")
+    parser.add_argument("-dk", "--data_key", type=str, default="contents",
+                        help="Name of the dataset field that contains the text")
+    parser.add_argument("-jn", "--json_name", type=str, default=None,
+                        help="Full path to dataset jsonl file. If None, will HuggingFace download instead.")
+    parser.add_argument("-hp", "--hf_path", type=str, default=None,
+                        help="HuggingFace path to the dataset, e.g. `jenhsia/ragged`. If None, assumes JSON loading.")
+    # data processing arguments
+    parser.add_argument("-nv", "--number_vec_shards", type=int, default=1,
+                        help="The number of overall shards of the output")
+    parser.add_argument("-b", "--batch_size", type=int, default=512,
+                        help="Batch size for running inference on embedding model")
+    parser.add_argument("-sv", "--start_vector", type=int, default=0,
+                        help="Vector ID to start from. Allows you to restart if needed.")
+    parser.add_argument("-ev", "--end_vector", type=int, default=None,
+                        help="Vector ID to end with. Allows you to fill in data if needed.")
+    parser.add_argument("-mp", "--multiproc", action="store_true",
+                        help="Enables multi-device inference")
+    parser.add_argument("-c", "--chunk_size", type=int, default=None,
+                        help="For multiprocessing, a chunk is the number of sentences to send for processing on a "
+                             "given device. It's required that chunk_size >= batch_size.")
+    # output arguments
+    parser.add_argument("-ot", "--tmp_output_dir", type=str, default="/var/tmp/svs",
+                        help="Intermediate output directory of memory mapped files.")
+    parser.add_argument("-op", "--output_prefix", type=str, required=True,
+                        help="Output filename prefix")
+    parser.add_argument("-of", "--final_output_dir", type=str, required=True,
+                        help="Final output directory of the .fvecs embedding file.")
+    parser.add_argument("--combine_only", action="store_true",
+                        help="Skip embedding and only do the combination / fvec conversion")
+    args = parser.parse_args()
+    print(args)
+
+    if args.hf_path is None and args.json_name is None:
+        raise ValueError("You must specify where to find the dataset, either through `--hf_path` or `--json_name`.")
+    print(args)
+
+    arg_dict = vars(args)
+
+    main(**arg_dict)
+


### PR DESCRIPTION
Generates a large vector dataset from text inputs. Gives two examples using the KILT Wikipedia dump, using different preprocessing and different text embedding models.

This implementation allows parallelization across GPU devices for high-dimensional embeddings, and writes to a memory mapped array before converting to *vecs format.